### PR TITLE
Bug/bomber shortcode

### DIFF
--- a/wp-content/themes/aerospace/inc/custom-post-meta.php
+++ b/wp-content/themes/aerospace/inc/custom-post-meta.php
@@ -36,7 +36,6 @@ function post_build_meta_box( $post ) {
 	$current_disable_highlights = get_post_meta( $post->ID, '_post_disable_highlights', true );
 	$current_disable_feature_img = get_post_meta( $post->ID, '_post_disable_feature_img', true );
 	$current_report_cover_url = get_post_meta( $post->ID, '_post_report_cover_url', true );
-	$current_disable_post_bottom_icon = get_post_meta( $post->ID, '_post_disable_post_bottom_icon', true );
 	$current_disable_post_authors = get_post_meta( $post->ID, '_post_disable_post_authors', true );
 	$current_disable_post_categories = get_post_meta( $post->ID, '_post_disable_post_categories', true );
 	$current_custom_css = get_post_meta( $post->ID, '_post_custom_css', true );
@@ -206,12 +205,6 @@ function post_save_meta_box_data( $post_id ) {
 		update_post_meta( $post_id, '_post_disable_feature_img', sanitize_text_field( $_POST['disable_feature_img'] ) );
 	} else {
 		update_post_meta( $post_id, '_post_disable_feature_img', '' );
-	}
-	// Disable Icon at Bottom of posts.
-	if ( isset( $_REQUEST['disable_post_bottom_icon'] ) ) {
-		update_post_meta( $post_id, '_post_disable_post_bottom_icon', sanitize_text_field( $_POST['disable_post_bottom_icon'] ) );
-	} else {
-		update_post_meta( $post_id, '_post_disable_post_bottom_icon', '' );
 	}
 	// Disable Authors at Bottom of the post.
 	if ( isset( $_REQUEST['disable_post_authors'] ) ) {

--- a/wp-content/themes/aerospace/inc/template-functions.php
+++ b/wp-content/themes/aerospace/inc/template-functions.php
@@ -150,7 +150,7 @@ function aerospace_add_logo_to_post_content( $content ) {
     }
     return $content;
 }
-add_filter('the_content', 'aerospace_add_logo_to_post_content', 0);
+// add_filter('the_content', 'aerospace_add_logo_to_post_content', 0);
 
 /**
  * Fixes empty <p> and <br> tags showing before and after shortcodes in the

--- a/wp-content/themes/aerospace/inc/template-functions.php
+++ b/wp-content/themes/aerospace/inc/template-functions.php
@@ -140,16 +140,16 @@ add_filter('img_caption_shortcode', 'aerospace_img_caption_shortcode_filter',10,
  * @param  string $content The post content.
  * @return string          The modified post content.
  */
-function aerospace_add_logo_to_post_content( $content ) {
-    global $post;
-    if ( $post->post_type == 'post' ) {
-        $disable_icon = get_post_meta( $post->ID, '_post_disable_post_bottom_icon', true );
-        if ( ! $disable_icon ) {
-            $content .= do_shortcode('[aircraft]');
-        }
-    }
-    return $content;
-}
+// function aerospace_add_logo_to_post_content( $content ) {
+//     global $post;
+//     if ( $post->post_type == 'post' ) {
+//         $disable_icon = get_post_meta( $post->ID, '_post_disable_post_bottom_icon', true );
+//         if ( ! $disable_icon ) {
+//             $content .= do_shortcode('[aircraft]');
+//         }
+//     }
+//     return $content;
+// }
 // add_filter('the_content', 'aerospace_add_logo_to_post_content', 0);
 
 /**


### PR DESCRIPTION
The first two steps in issue #54 are completed. I've been looking into methods of making the bomber icon shortcode available in the toolbar. 

I'm able to add a button into the toolbar using the format API so that's awesome! Screenshot below,
![Screen Shot 2019-04-15 at 11 11 06 AM](https://user-images.githubusercontent.com/30706065/56143825-3f542b00-5f6f-11e9-9878-579bf884a4c8.png)

However the biggest hurdle I'm having right now is how to add the shortcode into that button. There's a few methods in rich-text that are possible to use, linked [here](https://wordpress.org/gutenberg/handbook/designers-developers/developers/packages/packages-rich-text/). I've been experimenting with applyFormat and toggleFormat. These do work in the sense that I'm able to insert code that's similar to the shortcode as per the screenshot below,
![Screen Shot 2019-04-15 at 11 11 18 AM](https://user-images.githubusercontent.com/30706065/56143857-4f6c0a80-5f6f-11e9-8862-9879c4c577a2.png)

The main problem is I'm unable to set an src link to the image using these methods. I can set a background url for this element with the bomber image in css, however I know that's kind of hacky.

Another possible solution I've found is that perhaps it's possible to create a Gutenberg block that would be the bomber icon and then making this block inline with css. Here is a [link](https://github.com/WordPress/gutenberg/issues/10235) to an issue on the gutenberg repository that references this.