### PR TITLE
Mad/data archive bug

### DIFF
--- a/wp-content/themes/aerospace/archive-data.php
+++ b/wp-content/themes/aerospace/archive-data.php
@@ -41,7 +41,6 @@ get_header(); ?>
 			<div class="archive-pages-top row">
 				<?php if ( have_posts() ) : ?>
 					<div class="col-xs-12 col-sm archives-meta-left">
-						<?php aerospace_post_num(); ?>
 					</div>
 					<div class="col-xs-12 col-sm-6 archives-meta-right">
 						<div class="sort-filter">
@@ -89,10 +88,7 @@ get_header(); ?>
 		</section>
 		<?php if (have_posts() ) : ?>
 		<footer class="archive-pages-bottom row">
-            <div class="col-xs-12 col-sm archives-meta-left"><?php aerospace_post_num(); ?></div>
-            <div class="col-xs-12 col-sm-6 archives-meta-right">
                
-    		</div>
     	</footer>
     <?php endif; ?>
 	</main><!-- #main -->

--- a/wp-content/themes/aerospace/archive-data.php
+++ b/wp-content/themes/aerospace/archive-data.php
@@ -7,6 +7,13 @@
  * @package Aerospace
  */
 
+$args = array(
+	'post_type' => 'data',
+	'posts_per_page' => -1
+);
+
+$result = new WP_Query($args);
+
 if ( get_archive_top_content() ) {
     $description = get_archive_top_content();
 } else {
@@ -23,56 +30,75 @@ if ( get_archive_bottom_content() ) {
 get_header(); ?>
 
 <div id="primary" class="content-area">
-  <main id="main" class="site-main content-wrapper">
-    <header class="page-header row">
-      <div class="title-container">
-      <?php the_archive_title('<h1 class="page-title">', '</h1>'); ?>
-      <div class="archive-description row">
+	<main id="main" class="site-main content-wrapper">
+		<header class="page-header row">
+			<div class="title-container">
+			<?php the_archive_title('<h1 class="page-title">', '</h1>'); ?>
+			<div class="archive-description row">
                 <?php echo $description_extra; ?>
                 <?php echo $description; ?>
             </div>
-      <div class="archive-pages-top row">
-        <?php if (have_posts() ) : ?>
-          <div class="col-xs-12 col-sm archives-meta-left">
-            <?php aerospace_post_num(); ?>
-          </div>
+			<div class="archive-pages-top row">
+				<?php if ( have_posts() ) : ?>
+					<div class="col-xs-12 col-sm archives-meta-left">
+						<?php aerospace_post_num(); ?>
+					</div>
+					<div class="col-xs-12 col-sm-6 archives-meta-right">
+						<div class="sort-filter">
+							<span class="meta-label">Sort By:</span>
+							<button class="btn-sort tableSort active" data-sortCol="2" aria-label="Sort by Date">Date</button>
+							<span class="sort-filter-divider">|</span>
+							<button class="btn-sort tableSort" data-sortCol="1" aria-label="Sort by Title">Title</button>
+						</div>
+					</div>
+				<?php endif; ?>
+			</div>
+		</header><!-- .page-header -->
+		<section class="archive-content row">
+			<?php  if ( $result->have_posts() ) : ?>
+			<div class="col-xs-12 col-md-3 filter-sidebar">
+				<?php get_template_part( 'components/filters-data'); ?>
+			</div>
+			<div class="col-xs-12 col-md-9">
 
-        <?php endif; ?>
-      </div>
-    </header><!-- .page-header -->
-    <section class="archive-content row temp-data-archive">
-      <?php if (have_posts() ) : ?>
+				<table id="dataRepo" class="cards is-hidden">
+					<thead>
+						<tr>
+							<th>Display</th>
+							<th>Title</th>
+							<th>Last Updated</th>
+							<th>category</th>
+							<th>Tag</th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php
+						/* Start the Loop */
+						while ($result->have_posts()) : $result->the_post();
+							get_template_part( 'template-parts/content-data' );
+						endwhile;
+						?>
+					</tbody>
+				</table>
+			</div>
+			<?php
+			else :
+			get_template_part( 'template-parts/content', 'none' );
 
-        <table class="cards is-hidden">
-          <tbody>
-            <?php
-            /* Start the Loop */
-            while ( have_posts() ) : the_post();
-              get_template_part( 'template-parts/content-data' );
-            endwhile;
-            ?>
-          </tbody>
-        </table>
-      <?php
-      else :
-      get_template_part( 'template-parts/content', 'none' );
-
-      endif; ?>
-    </section>
-    <?php if (have_posts() ) : ?>
-    <footer class="archive-pages-bottom row">
+			endif; ?>
+		</section>
+		<?php if (have_posts() ) : ?>
+		<footer class="archive-pages-bottom row">
             <div class="col-xs-12 col-sm archives-meta-left"><?php aerospace_post_num(); ?></div>
             <div class="col-xs-12 col-sm-6 archives-meta-right">
-                <?php the_posts_pagination( array(
-                    'prev_text' => '<i class="icon-arrow-left"></i>',
-                    'next_text' => '<i class="icon-arrow-right"></i>',
-                )); ?>
-        </div>
-      </footer>
+               
+    		</div>
+    	</footer>
     <?php endif; ?>
-  </main><!-- #main -->
+	</main><!-- #main -->
 </div><!-- #primary -->
 
 <?php
+wp_enqueue_script('aerospace-datatables', '//cdn.datatables.net/1.10.16/js/jquery.dataTables.min.js', array(), '20171128', true );
+wp_enqueue_script('aerospace-datarepo', get_template_directory_uri() . '/js/data-repo.js', array(), '20171128', true );
 get_footer();
-

--- a/wp-content/themes/aerospace/js/data-repo.js
+++ b/wp-content/themes/aerospace/js/data-repo.js
@@ -7,6 +7,7 @@
 		"info": false,
 		"lengthChange": false,
 		"order": [[ 2, "desc" ]],
+		"paging": true,
 		"pageLength": 10,
 		"pagingType": "simple_numbers",
 		"language": {

--- a/wp-content/themes/aerospace/js/data-repo.js
+++ b/wp-content/themes/aerospace/js/data-repo.js
@@ -7,7 +7,6 @@
 		"info": false,
 		"lengthChange": false,
 		"order": [[ 2, "desc" ]],
-		"paging": true,
 		"pageLength": 10,
 		"pagingType": "simple_numbers",
 		"language": {


### PR DESCRIPTION
## What
Fixing bug from #73 

The default limit for number of posts per page is 10, and WordPress will fetch additional posts upon the user clicking the "next" pagination button. [This is the pagination used](https://codex.wordpress.org/Pagination) on the temporary fix table. `dataTables.js` wasn't able to paginate because WordPress was only grabbing ten posts at a time.

## Fix

* Replace `archive-data` with content that had been moved to `dataTable-archive-data`
Copy content from old file and replace content of the temporary fix in `archive-data`.

* Add new `wp_query` to the archive-data file
To fix the bug caused by WordPress not fetching all posts at once, create a new `wp_query` asking for all posts of type `data` and set `-1` (no limit) for `posts_per_page`. Save this as `$result` and use this query in the if/while statements that create the table. 

* Remove `aerospace_post_num()` usage. Other archives use this function to render "PAGE X/Y" at the top and bottom of their pages. Because the data for this table is now fetched in advance, going to the next page of the table doesn't trigger a page re-render so the "PAGE 1/2" never updates to "PAGE 2/2". While php is removed, leave the `div`s in place so the styling isn't affected.

## Video
Zoomed way out so it would fit on one screen without scrolling:

https://user-images.githubusercontent.com/41589348/173676960-5c2dd3b1-6a4d-4e9a-aae1-093b2cb082a7.mov



